### PR TITLE
improve scaling when uploading larger scale images

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='image_in_gh_commit_calendar',
-    version='0.0.2',
+    version='0.0.3',
     author='Igor Vaiman',
     description='Cutting-edge GitHub page customization tool',
     packages=find_packages(where='src'),

--- a/src/image_in_gh_commit_calendar/image2calendar.py
+++ b/src/image_in_gh_commit_calendar/image2calendar.py
@@ -44,7 +44,7 @@ def image2calendar(
     img = ImageOps.grayscale(img)
     img = ImageOps.invert(img)
     img = img.resize(
-        (GITHUB_CALENDAR_WEEKS, GITHUB_CALENDAR_DAYS_PER_WEEK), resample=Image.BILINEAR
+        (GITHUB_CALENDAR_WEEKS, GITHUB_CALENDAR_DAYS_PER_WEEK), resample=Image.HAMMING
     )
 
     if save_preview_to is not None:


### PR DESCRIPTION
From the docs:
> Produces a sharper image than BILINEAR, doesn’t have dislocations on local level like with BOX. This filter can only be used with the resize() and thumbnail() methods.

https://pillow.readthedocs.io/en/stable/handbook/concepts.html#PIL.Image.HAMMING

### Examples

BILINEAR with 10x scale down and zoomed:
![Screen Shot 2021-10-21 at 10 44 03 PM](https://user-images.githubusercontent.com/1782569/138348816-6df22de9-16df-4a27-90cb-0e593982c697.png)

HAMMING with 10x scale down and zoomed:
![Screen Shot 2021-10-21 at 10 44 12 PM](https://user-images.githubusercontent.com/1782569/138348804-3d87e45b-d30a-4d54-b075-db38ac560fa4.png)
